### PR TITLE
Fix product grid layout persistence across viewports

### DIFF
--- a/assets/results-list.js
+++ b/assets/results-list.js
@@ -69,7 +69,7 @@ export default class ResultsList extends PaginatedList {
     if (!(targetElement instanceof HTMLInputElement)) return;
 
     targetElement.checked = true;
-    this.#setLayout('default');
+    this.#setLayout(targetElement.value);
   };
 }
 

--- a/snippets/product-grid.liquid
+++ b/snippets/product-grid.liquid
@@ -141,7 +141,9 @@
         const storedLayout = sessionStorage.getItem(`product-grid-view-${currentDevice}`);
 
         if (storedLayout) {
-          const options = document.querySelectorAll(`input[type="radio"][name="grid"]`);
+          const options = document.querySelectorAll(
+            'input[type="radio"][name="grid"], input[type="radio"][name="grid-mobile"]'
+          );
 
           grid.setAttribute('product-grid-view', storedLayout);
 


### PR DESCRIPTION
## Summary
- ensure the product grid keeps the selected layout when the viewport changes by applying the target radio value
- update the product grid script to sync stored layouts with both desktop and mobile radio controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9c9841ec83338445b624f7e9cded