### PR TITLE
Add product group color selector snippet

### DIFF
--- a/snippets/product-group-color-selector.liquid
+++ b/snippets/product-group-color-selector.liquid
@@ -1,0 +1,79 @@
+{% liquid
+  assign color_group = product.metafields.custom.product_group.value
+  if color_group == blank
+    return
+  endif
+
+  assign group_products = color_group.products | compact
+  if group_products == blank or group_products.size == 0
+    return
+  endif
+%}
+
+{% if context == 'product' %}
+  <fieldset class="variant-option variant-option--buttons variant-option--swatches product-group-colors">
+    <legend class="product-group-colors__legend">Cor</legend>
+    {% for group_product in group_products %}
+      {% liquid
+        assign group_variant = group_product.selected_or_first_available_variant
+        assign color_label = group_variant.option1
+        if color_label == blank
+          assign color_label = group_product.title
+        endif
+
+        assign swatch_image = group_product.featured_media | image_url: width: 80
+        assign is_active_product = group_product.id == product.id
+      %}
+      <a
+        href="{{ group_product.url }}"
+        class="product-group-colors__option{% if is_active_product %} product-group-colors__option--active{% endif %}"
+        {% if is_active_product %}aria-current="true"{% endif %}
+      >
+        <span class="product-group-colors__swatch" aria-hidden="true">
+          {% if swatch_image != blank %}
+            <img src="{{ swatch_image }}" alt="" loading="lazy" width="40" height="40">
+          {% endif %}
+        </span>
+        <span class="product-group-colors__label visually-hidden">{{ color_label }}</span>
+      </a>
+    {% endfor %}
+    <input
+      type="hidden"
+      class="product-group-colors__hidden-input"
+      name="options[{{ option_name }}]"
+      value="{{ product.selected_or_first_available_variant.option1 }}"
+    >
+  </fieldset>
+  {% if native_option %}
+    <div class="product-group-colors__native">
+      {{ native_option }}
+    </div>
+  {% endif %}
+{% elsif context == 'card' %}
+  <div class="product-group-colors product-group-colors--card">
+    {% for group_product in group_products %}
+      {% liquid
+        assign group_variant = group_product.selected_or_first_available_variant
+        assign color_label = group_variant.option1
+        if color_label == blank
+          assign color_label = group_product.title
+        endif
+
+        assign swatch_image = group_product.featured_media | image_url: width: 80
+        assign is_active_product = group_product.id == product.id
+      %}
+      <a
+        href="{{ group_product.url }}"
+        class="product-group-colors__option{% if is_active_product %} product-group-colors__option--active{% endif %}"
+        {% if is_active_product %}aria-current="true"{% endif %}
+      >
+        <span class="product-group-colors__swatch" aria-hidden="true">
+          {% if swatch_image != blank %}
+            <img src="{{ swatch_image }}" alt="" loading="lazy" width="40" height="40">
+          {% endif %}
+        </span>
+        <span class="product-group-colors__label visually-hidden">{{ color_label }}</span>
+      </a>
+    {% endfor %}
+  </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- add a reusable product group color selector snippet for product and card contexts
- fetch related products from the product group metaobject and render swatch links with active state handling
- preserve the selected color option and expose helper classes for styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9ed358b48333b431435efde80ae2