### PR TITLE
Render product group color selector on product cards

### DIFF
--- a/sections/section-rendering-product-card.liquid
+++ b/sections/section-rendering-product-card.liquid
@@ -40,6 +40,9 @@
     <product-price>
       {% render 'price', product_resource: product, show_unit_price: true %}
     </product-price>
+    {% if product.metafields.custom.product_group.value != blank %}
+      {% render 'product-group-color-selector', product: product, option_name: 'Cor', context: 'card' %}
+    {% endif %}
   </a>
 </product-card>
 {%- if settings.transition_to_main_product -%}


### PR DESCRIPTION
## Summary
- render the product group color selector on product cards when group metafield data is available
- invoke the selector with the card context so the card-specific styling is applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa4556c648333a81f8c7132fe758c