### PR TITLE
Fix variant picker URL handling for combined listings

### DIFF
--- a/assets/variant-picker.js
+++ b/assets/variant-picker.js
@@ -51,7 +51,9 @@ export default class VariantPicker extends Component {
 
     this.fetchUpdatedSection(this.buildRequestUrl(selectedOption), loadsNewProduct);
 
-    const url = new URL(window.location.href);
+    const url = loadsNewProduct
+      ? new URL(newUrl, window.location.origin)
+      : new URL(window.location.href);
 
     const variantId = selectedOption.dataset.variantId || null;
 
@@ -61,11 +63,6 @@ export default class VariantPicker extends Component {
       } else {
         url.searchParams.delete('variant');
       }
-    }
-
-    // Change the path if the option is connected to another product via combined listing.
-    if (loadsNewProduct) {
-      url.pathname = newUrl;
     }
 
     if (url.href !== window.location.href) {


### PR DESCRIPTION
## Summary
- instantiate a new URL from the connected product when swapping to a sibling product
- ensure the variant parameter is applied to the rebuilt URL before updating browser history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd53675d483339ac2b66fa7a8d043